### PR TITLE
Further fixups to remove -fcf-protection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,7 @@ RUN cd bitcoin/ && \
 
 RUN cd bitcoin/ && cmake -B build_fuzz \
       --toolchain ./depends/$(./depends/config.guess)/toolchain.cmake \
+      -DSANITIZERS="address" \
       -DAPPEND_CPPFLAGS="-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION" \
       -DAPPEND_LDFLAGS="-fuse-ld=lld-${LLVM_V}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,8 +85,10 @@ RUN sed -i --regexp-extended '/.*rm -rf .*extract_dir.*/d' ./bitcoin/depends/fun
       -j$(nproc)
 
 COPY ./target-patches/bitcoin-core-rng.patch bitcoin/
+COPY ./target-patches/remove_fcf_protection.patch bitcoin/
 RUN cd bitcoin/ && \
-      git apply bitcoin-core-rng.patch
+      git apply bitcoin-core-rng.patch && \
+      git apply remove_fcf_protection.patch
 
 RUN cd bitcoin/ && cmake -B build_fuzz \
       --toolchain ./depends/$(./depends/config.guess)/toolchain.cmake \

--- a/target-patches/remove_fcf_protection.patch
+++ b/target-patches/remove_fcf_protection.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 99490f742a..2df65629a0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -527,7 +527,6 @@ else()
+ 
+   try_append_cxx_flags("-Wstack-protector" TARGET core_interface SKIP_LINK)
+   try_append_cxx_flags("-fstack-protector-all" TARGET core_interface)
+-  try_append_cxx_flags("-fcf-protection=full" TARGET core_interface)
+ 
+   if(MINGW)
+     # stack-clash-protection is a no-op for Windows.


### PR DESCRIPTION
Overriding doesn't work properly, and will need further fixes upstream.
Patch it out for now. Re-enable address sanitizer. Keep using `lld`.
Tested that this compiles on x86_64.