### PR TITLE
docs: fuzzamoto-libafl: fix cmd to create a new container

### DIFF
--- a/doc/src/usage/libafl.md
+++ b/doc/src/usage/libafl.md
@@ -26,7 +26,7 @@ And then create a new container from it (mounting the current directory to
 `/fuzzamoto`):
 
 ```
-docker run --privileged -it fuzzamoto-libafl -v $PWD:/fuzzamoto bash
+docker run --privileged -it -v $PWD:/fuzzamoto fuzzamoto-libafl bash
 ```
 
 `--privileged` is required to enable the use of kvm by Nyx.


### PR DESCRIPTION
It fixes the command to create a new container to fuzz with libafl. Just noticed it when trying to run it.