### PR TITLE
libafl: drop SHELL from Dockerfile

### DIFF
--- a/Dockerfile.libafl
+++ b/Dockerfile.libafl
@@ -1,5 +1,4 @@
 FROM debian:bookworm
-SHELL ["/bin/bash", "-c"]
 
 # ------ Build and install dependencies ------
 


### PR DESCRIPTION
If this is no-longer needed, would be good to drop, as it's ignored by podman in any case. i.e:

```bash
STEP 2/36: SHELL ["/bin/bash", "-c"]
time="2025-07-14T17:03:52+01:00" level=warning msg="SHELL is not supported for OCI image format, [/bin/bash -c] will be ignored. Must use `docker` format"
--> 4a5a9a3a1d5c
STEP 3/36: RUN apt-get update
Get:1 http://deb.debian.org/debian bookworm InRelease [151 kB]
Get:2 http://deb.debian.org/debian bookworm-updates InRelease [55.4 kB]
Get:3 http://deb.debian.org/debian-security bookworm-security InRelease [48.0 kB]
Get:4 http://deb.debian.org/debian bookworm/main arm64 Packages [8693 kB]
Get:5 http://deb.debian.org/debian bookworm-updates/main arm64 Packages [756 B]
Get:6 http://deb.debian.org/debian-security bookworm-security/main arm64 Packages [268 kB]
Fetched 9216 kB in 1s (6274 kB/s)
Reading package lists...
time="2025-07-14T17:03:55+01:00" level=warning msg="SHELL is not supported for OCI image format, [/bin/bash -c] will be ignored. Must use `docker` format"
--> 272709b0ac4c
STEP 4/36: ARG LLVM_V=19
time="2025-07-14T17:03:56+01:00" level=warning msg="SHELL is not supported for OCI image format, [/bin/bash -c] will be ignored. Must use `docker` format"
```

Didn't see any issues building with podman on `x86_64`.