### PR TITLE
doc: clarify that HOST_OUTPUT_DIR, HOST_CORPUS_DIR are env variables

### DIFF
--- a/doc/src/usage/coverage.md
+++ b/doc/src/usage/coverage.md
@@ -14,5 +14,5 @@ Example:
 
 ```
 docker build -t fuzzamoto-coverage -f Dockerfile.coverage .
-docker run --privileged -it -v HOST_OUTPUT_DIR:/mnt/output -v HOST_CORPUS_DIR:/mnt/corpus fuzzamoto-coverage /fuzzamoto/target/release/scenario-compact-blocks
+docker run --privileged -it -v $HOST_OUTPUT_DIR:/mnt/output -v $HOST_CORPUS_DIR:/mnt/corpus fuzzamoto-coverage /fuzzamoto/target/release/scenario-compact-blocks
 ```


### PR DESCRIPTION
I missed this in https://github.com/dergoegge/fuzzamoto/pull/19 and stumbled on it when running coverage.