### PR TITLE
Update update on docker command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,10 @@ FROM debian:bookworm
 
 # ------ Build and install dependencies ------
 
-RUN apt-get update -y
-
 ARG LLVM_V=19
 
 # Make sure we can install the llvm toolchain
-RUN apt-get install -y software-properties-common
+RUN apt-get update && apt-get install -y software-properties-common
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421
 RUN apt-add-repository "deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-${LLVM_V} main"
 RUN apt-add-repository "deb-src http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-${LLVM_V} main"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:bookworm
 
 # ------ Build and install dependencies ------
 
-RUN apt-get update
+RUN apt-get update -y
 
 ARG LLVM_V=19
 

--- a/Dockerfile.libafl
+++ b/Dockerfile.libafl
@@ -2,12 +2,10 @@ FROM debian:bookworm
 
 # ------ Build and install dependencies ------
 
-RUN apt-get update -y
-
 ARG LLVM_V=19
 
 # Make sure we can install the llvm toolchain
-RUN apt-get install -y software-properties-common
+RUN apt-get update && apt-get install -y software-properties-common
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421
 RUN apt-add-repository "deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-${LLVM_V} main"
 RUN apt-add-repository "deb-src http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-${LLVM_V} main"

--- a/Dockerfile.libafl
+++ b/Dockerfile.libafl
@@ -2,7 +2,7 @@ FROM debian:bookworm
 
 # ------ Build and install dependencies ------
 
-RUN apt-get update
+RUN apt-get update -y
 
 ARG LLVM_V=19
 


### PR DESCRIPTION
Hi!

While building the Docker I obtained the following error:

```
 => [ 1/49] FROM docker.io/library/debian:bookworm                                     0.0s
 => CACHED [ 2/49] RUN apt-get update                                                            0.0s
 => ERROR [ 3/49] RUN apt-get install -y software-properties-common       
```

It turns out  if one already have a cached version of `apt-get update` the subsequent install might triggers some 404 errors. Embedding the `update` on the same line than the `install` shall prevent this from happening.

Another option is to call `docker build --no-cache [...]` but it is probably better not having to use that option.
