### PR TITLE
Make it possible to fetch Core based on PR number

### DIFF
--- a/Dockerfile.libafl
+++ b/Dockerfile.libafl
@@ -58,7 +58,14 @@ RUN cd AFLplusplus && make PERFORMANCE=1 -j$(nproc --ignore 1)
 ARG OWNER=bitcoin
 ARG REPO=bitcoin
 ARG BRANCH=master
-RUN git clone --depth 1 --branch $BRANCH https://github.com/$OWNER/$REPO.git
+ARG PR_NUMBER=
+
+RUN git clone --depth 1 --branch "$BRANCH" "https://github.com/$OWNER/$REPO.git" && \
+    if [ -n "$PR_NUMBER" ]; then \
+        cd "$REPO" && \
+        git fetch --depth=1 origin "pull/$PR_NUMBER/head:pr-$PR_NUMBER" && \
+        git checkout "pr-$PR_NUMBER"; \
+    fi
 
 ENV CC=/AFLplusplus/afl-clang-fast
 ENV CXX=/AFLplusplus/afl-clang-fast++


### PR DESCRIPTION
It adds a `PR_NUMBER` parameter to be able to build Bitcoin Core from a PR by providing its number (It could be based on commit btw). If no `PR_NUMBER` is provided it will fetch it from `BRANCH`.