### PR TITLE
Add PredicateTxGenerator

### DIFF
--- a/fuzzamoto-ir/src/generators/block.rs
+++ b/fuzzamoto-ir/src/generators/block.rs
@@ -229,7 +229,7 @@ impl<R: RngCore> Generator<R> for TipBlockGenerator {
         &self,
         program: &crate::Program,
         rng: &mut R,
-        meta: Option<&PerTestcaseMetadata>,
+        meta: Option<&mut PerTestcaseMetadata>,
     ) -> Option<usize> {
         if let Some(meta) = meta.as_ref()
             && let Some(nth) = meta.recent_blocks.iter().max()
@@ -291,7 +291,7 @@ impl<R: RngCore> Generator<R> for ReorgBlockGenerator {
         &self,
         program: &crate::Program,
         rng: &mut R,
-        meta: Option<&PerTestcaseMetadata>,
+        meta: Option<&mut PerTestcaseMetadata>,
     ) -> Option<usize> {
         if let Some(meta) = meta.as_ref()
             && let Some(max) = meta.recent_blocks.iter().max_by_key(|i| i.defining_block.1)

--- a/fuzzamoto-ir/src/generators/block_txn.rs
+++ b/fuzzamoto-ir/src/generators/block_txn.rs
@@ -123,7 +123,7 @@ impl<R: RngCore> Generator<R> for BlockTxnGenerator {
         &self,
         program: &crate::Program,
         rng: &mut R,
-        meta: Option<&PerTestcaseMetadata>,
+        meta: Option<&mut PerTestcaseMetadata>,
     ) -> Option<usize> {
         if let Some(meta) = meta
             && !meta.block_txn_request().is_empty()

--- a/fuzzamoto-ir/src/generators/mod.rs
+++ b/fuzzamoto-ir/src/generators/mod.rs
@@ -66,7 +66,7 @@ pub trait Generator<R: RngCore> {
         &self,
         program: &Program,
         rng: &mut R,
-        _meta: Option<&PerTestcaseMetadata>,
+        _meta: Option<&mut PerTestcaseMetadata>,
     ) -> Option<usize> {
         program.get_random_instruction_index(rng, self.requested_context())
     }

--- a/fuzzamoto-ir/src/metadata.rs
+++ b/fuzzamoto-ir/src/metadata.rs
@@ -1,12 +1,13 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{GetBlockTxn, RecentBlock};
+use crate::{GetBlockTxn, MempoolTxo, RecentBlock, TxoMetadata};
 
 /// The runtime data observed during the course of harness execution
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct PerTestcaseMetadata {
     pub block_txn_request: Vec<GetBlockTxn>,
     pub recent_blocks: Vec<RecentBlock>,
+    pub txo_metadata: TxoMetadata,
 }
 
 impl PerTestcaseMetadata {
@@ -14,6 +15,7 @@ impl PerTestcaseMetadata {
         Self {
             block_txn_request: Vec::new(),
             recent_blocks: Vec::new(),
+            txo_metadata: TxoMetadata::default(),
         }
     }
 
@@ -25,6 +27,14 @@ impl PerTestcaseMetadata {
         &self.recent_blocks
     }
 
+    pub fn txo_metadata(&self) -> &TxoMetadata {
+        &self.txo_metadata
+    }
+
+    pub fn txo_metadata_mut(&mut self) -> &mut TxoMetadata {
+        &mut self.txo_metadata
+    }
+
     pub fn add_block_tx_request(&mut self, req: GetBlockTxn) {
         self.block_txn_request.push(req);
     }
@@ -32,5 +42,12 @@ impl PerTestcaseMetadata {
     pub fn add_recent_blocks(&mut self, blocks: Vec<RecentBlock>) {
         self.recent_blocks = blocks;
         self.recent_blocks.sort();
+    }
+    pub fn add_txo_entry(&mut self, txo_entry: Vec<MempoolTxo>) {
+        let txo_metadata = TxoMetadata {
+            txo_entry,
+            choice: None,
+        };
+        self.txo_metadata = txo_metadata;
     }
 }

--- a/fuzzamoto-libafl/src/instance.rs
+++ b/fuzzamoto-libafl/src/instance.rs
@@ -5,10 +5,10 @@ use fuzzamoto_ir::{
     BlockGenerator, BlockTxnGenerator, BloomFilterAddGenerator, BloomFilterClearGenerator,
     BloomFilterLoadGenerator, CombineMutator, CompactBlockGenerator, CompactFilterQueryGenerator,
     GetAddrGenerator, GetDataGenerator, HeaderGenerator, InputMutator, InventoryGenerator,
-    LargeTxGenerator, LongChainGenerator, OneParentOneChildGenerator, OperationMutator, Program,
-    ReorgBlockGenerator, SendBlockGenerator, SendMessageGenerator, SingleTxGenerator,
-    TipBlockGenerator, TxoGenerator, WitnessGenerator, cutting::CuttingMinimizer,
-    instr_block::InstrBlockMinimizer, nopping::NoppingMinimizer,
+    LargeTxGenerator, LongChainGenerator, OneParentOneChildGenerator, OperationMutator,
+    PredicateTxGenerator, Program, ReorgBlockGenerator, SendBlockGenerator, SendMessageGenerator,
+    SingleTxGenerator, TipBlockGenerator, TxoGenerator, WitnessGenerator,
+    cutting::CuttingMinimizer, instr_block::InstrBlockMinimizer, nopping::NoppingMinimizer,
 };
 
 use libafl::{
@@ -282,6 +282,10 @@ where
                     TipBlockGenerator::new(full_program_context.headers.clone()),
                     rng.clone()
                 )
+            ),
+            (
+                100.0,
+                IrGenerator::new(PredicateTxGenerator::any(), rng.clone())
             ),
             (
                 100.0,

--- a/fuzzamoto-libafl/src/mutators.rs
+++ b/fuzzamoto-libafl/src/mutators.rs
@@ -216,7 +216,7 @@ where
         let is_first = rt_data.mutation_idx() == 0;
         rt_data.increment_idx();
 
-        let tc_data = if is_first
+        let mut tc_data = if is_first
             && let Some(id) = current_id
             && let Some(meta) = rt_data.metadata_mut(id)
         {
@@ -227,7 +227,7 @@ where
 
         let Some(index) =
             self.generator
-                .choose_index(input.ir(), &mut self.rng, tc_data.as_deref())
+                .choose_index(input.ir(), &mut self.rng, tc_data.as_deref_mut())
         else {
             return Ok(MutationResult::Skipped);
         };

--- a/fuzzamoto-libafl/src/stages/probe.rs
+++ b/fuzzamoto-libafl/src/stages/probe.rs
@@ -78,6 +78,15 @@ where
                     txvec.add_block_tx_request(get_block_txn.clone());
                 }
             }
+            ProbeResult::Mempool { txo_entry } => {
+                let current = *state.corpus().current();
+                if let Some(cur) = current
+                    && let Ok(meta) = state.metadata_mut::<RuntimeMetadata>()
+                {
+                    let txvec = meta.metadatas.entry(cur).or_default();
+                    txvec.add_txo_entry(txo_entry.clone());
+                }
+            }
             ProbeResult::Failure { command, reason } => {
                 log::info!(
                     "Command {:?} couln't be parsed; reason: {:?}",


### PR DESCRIPTION
This PR adds `PredicateTxGenerator` that

1. probes the transactions inside the mempools
2. based on the mempools's utxos, we decide to chain more transactions to it. How we choose the transactions to put onto is decided by a predicate given by the user of this module

for example:
- PredicateTxGenerator::double_spend() is the same as the previous `DoubleSpendGenerator` that spends a transaction who has another existing transactions that spend it.
- PredicateTxGenerator::chain_spend() extends the chain of transactions, it looks for a transaction that nobody spends, and if it is found, it just spends it.