### PR TITLE
ir: skip TakeTxo for OutputType::OpReturn

### DIFF
--- a/fuzzamoto-ir/src/generators/tx.rs
+++ b/fuzzamoto-ir/src/generators/tx.rs
@@ -174,9 +174,12 @@ fn build_tx<R: RngCore>(
         &Operation::EndBuildTx,
     );
 
-    // Make every output of the transaction spendable
+    // Make every output of the transaction spendable except OpReturn
     let mut outputs = Vec::new();
     for (_, output_type) in output_amounts {
+        if matches!(output_type, OutputType::OpReturn) {
+            continue;
+        }
         let mut txo_var =
             builder.force_append_expect_output(vec![const_tx_var.index], &Operation::TakeTxo);
         if matches!(output_type, OutputType::PayToTaproot) && rng.gen_bool(0.5) {


### PR DESCRIPTION
I noticed `LargeTxGenerator` creates many transactions each with a single `OpReturn` output that are all then marked as spendable with `TakeTxo`. Skip them instead.