### PR TITLE
target-patches: add signal handler to reset coverage counters

### DIFF
--- a/Dockerfile.coverage
+++ b/Dockerfile.coverage
@@ -57,6 +57,11 @@ COPY ./target-patches/bitcoin-core-aggressive-rng.patch bitcoin/
 RUN cd bitcoin/ && \
       git apply bitcoin-core-aggressive-rng.patch
 
+COPY ./target-patches/bitcoin-core-reset-coverage-counters.patch bitcoin/
+
+RUN cd bitcoin/ && \
+      git apply bitcoin-core-reset-coverage-counters.patch
+
 RUN cd bitcoin/ && cmake -B build_fuzz_cov \
       --toolchain ./depends/$(./depends/config.guess)/toolchain.cmake \
       -DAPPEND_CFLAGS="-fprofile-instr-generate -fcoverage-mapping" \
@@ -97,7 +102,7 @@ COPY ./Cargo.toml .
 RUN mkdir .cargo && cargo vendor > .cargo/config
 
 ENV BITCOIND_PATH=/bitcoin/build_fuzz_cov/bin/bitcoind
-RUN cargo build -p fuzzamoto-scenarios --bins -p fuzzamoto-cli --verbose --features "reproduce" --release
+RUN cargo build -p fuzzamoto-scenarios --bins -p fuzzamoto-cli --verbose --features "reproduce,coverage" --release
 
 ENV LLVM_V=${LLVM_V}
 

--- a/fuzzamoto-scenarios/Cargo.toml
+++ b/fuzzamoto-scenarios/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 [features]
 fuzz = ["compile_in_vm", "force_send_and_ping", "nyx"]
 reproduce = ["compile_in_vm", "force_send_and_ping", "fuzzamoto/reproduce"]
+coverage = ["fuzzamoto/coverage"]
 
 nyx = ["dep:fuzzamoto-nyx-sys"]
 compile_in_vm = []

--- a/fuzzamoto/Cargo.toml
+++ b/fuzzamoto/Cargo.toml
@@ -13,6 +13,7 @@ reproduce = ["reduced_pow", "inherit_stdout"]
 inherit_stdout = []             # Inherit stdout from the fuzz target(s)
 nyx = ["dep:fuzzamoto-nyx-sys"] # Use the nyx runner
 reduced_pow = []                # Use reduced POW for block generation
+coverage = []                   # Invokes patched signal handler in bitcoind
 
 [lints]
 workspace = true

--- a/fuzzamoto/src/scenarios/mod.rs
+++ b/fuzzamoto/src/scenarios/mod.rs
@@ -33,7 +33,7 @@ macro_rules! fuzzamoto_main {
         fn main() -> std::process::ExitCode {
             use env_logger;
             use fuzzamoto::runners::{Runner, StdRunner};
-            use std::process::ExitCode;
+            use std::process::{Command, ExitCode};
 
             env_logger::init();
 
@@ -52,6 +52,23 @@ macro_rules! fuzzamoto_main {
                     return ExitCode::from(exit_code);
                 }
             };
+
+            // Invoke the patched signal handler to reset coverage counters.
+            if cfg!(feature = "coverage") {
+                if let Ok(output) = Command::new("pgrep").arg("bitcoind").output() {
+                    let stdout = String::from_utf8_lossy(&output.stdout);
+                    let mut lines = stdout.lines();
+                    assert_eq!(lines.clone().count(), 1);
+                    let pid = lines.next().unwrap().trim();
+
+                    // Send SIGUSR1 to bitcoind which will invoke the patched signal handler.
+                    if let Ok(signal_output) = Command::new("kill").args(["-10", pid]).output() {
+                        assert!(signal_output.status.success());
+                    }
+                } else {
+                    return ExitCode::FAILURE;
+                }
+            }
 
             // Ensure the runner dropped prior to the scenario when returning from main.
             let runner = runner;

--- a/target-patches/bitcoin-core-reset-coverage-counters.patch
+++ b/target-patches/bitcoin-core-reset-coverage-counters.patch
@@ -1,0 +1,34 @@
+diff --git a/src/init.cpp b/src/init.cpp
+index 49cfc39423..6050a29175 100644
+--- a/src/init.cpp
++++ b/src/init.cpp
+@@ -433,6 +433,17 @@ static void HandleSIGHUP(int)
+ {
+     LogInstance().m_reopen_file = true;
+ }
++
++#if defined(__clang__)
++extern "C" __attribute__((weak)) void __llvm_profile_reset_counters(void);
++extern "C" __attribute__((weak)) void __llvm_profile_reset_counters(void) {}
++
++static void HandleSIGUSR1(int)
++{
++    __llvm_profile_reset_counters();
++}
++#endif
++
+ #else
+ static BOOL WINAPI consoleCtrlHandler(DWORD dwCtrlType)
+ {
+@@ -902,6 +913,11 @@ bool AppInitBasicSetup(const ArgsManager& args, std::atomic<int>& exit_status)
+     registerSignalHandler(SIGTERM, HandleSIGTERM);
+     registerSignalHandler(SIGINT, HandleSIGTERM);
+
++#if defined(__clang__)
++    // Wipe coverage counters on SIGUSR1
++    registerSignalHandler(SIGUSR1, HandleSIGUSR1);
++#endif
++
+     // Reopen debug.log on SIGHUP
+     registerSignalHandler(SIGHUP, HandleSIGHUP);
+


### PR DESCRIPTION
Adds a bitcoin core patch that sets up a custom signal handler for SIGUSR1 and calls `__llvm_profile_reset_counters`.  Signal after state setup is done.

Coverage with [master](https://crypt-iq.github.io/fuzz_coverage_reports/04092026-cov-nosignal-master/coverage-report/coverage/bitcoin/index.html).
Coverage with [this pull](https://crypt-iq.github.io/fuzz_coverage_reports/04092026-cov-reset-test/coverage-report/coverage/bitcoin/index.html).
(Note: check out `AppInitMain`, `LoadBlockIndex`, and similar.)

Fixes https://github.com/dergoegge/fuzzamoto/issues/9