### PR TITLE
Reduce peer timeout to prevent overflow

### DIFF
--- a/fuzzamoto/src/targets/bitcoin_core.rs
+++ b/fuzzamoto/src/targets/bitcoin_core.rs
@@ -72,7 +72,7 @@ impl BitcoinCoreTarget {
             "-maxmempool=5", // 5MB
             "-dbcache=4",    // 4MiB
             "-datacarriersize=1000000",
-            "-peertimeout=31556952000",
+            "-peertimeout=999999999",
             "-noconnect",
         ]);
         config


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin/pull/34882 switched `m_connected` and the inactivity checks to nanoseconds, so gotta reduce the peer timeout again. The new value (matching the functional tests) is still greater than the 21-year mocktime range set in https://github.com/dergoegge/fuzzamoto/pull/112.