### PR TITLE
fuzzamoto-nyx-sys: add SIGIOT to LD_PRELOAD sigaction disallow list

### DIFF
--- a/fuzzamoto-ir/src/builder.rs
+++ b/fuzzamoto-ir/src/builder.rs
@@ -259,16 +259,14 @@ impl ProgramBuilder {
         instruction.operation.check_input_types(&input_vars)?;
 
         match &instruction.operation {
-            Operation::LoadNode(idx) => {
-                if *idx >= self.context.num_nodes {
-                    return Err(ProgramValidationError::NodeNotFound(*idx));
-                }
+            Operation::LoadNode(idx) if *idx >= self.context.num_nodes => {
+                return Err(ProgramValidationError::NodeNotFound(*idx));
             }
-            Operation::LoadConnection(idx) => {
-                if *idx >= self.context.num_connections {
-                    return Err(ProgramValidationError::ConnectionNotFound(*idx));
-                }
+
+            Operation::LoadConnection(idx) if *idx >= self.context.num_connections => {
+                return Err(ProgramValidationError::ConnectionNotFound(*idx));
             }
+
             Operation::LoadConnectionType(connection_type) => match connection_type.as_str() {
                 "outbound" | "inbound" => {}
                 _ => {
@@ -587,13 +585,11 @@ impl ProgramBuilder {
                 Operation::TakeTxo | Operation::LoadTxo { .. } => {
                     utxos.insert(var_count);
                 }
-                Operation::AddTxInput => {
-                    if !utxos.remove(&instruction.inputs[1]) {
-                        continue;
-                    }
-                    // AddTxInput instructions have no output variables so we can remove them and
-                    // use `variable_count` above without issue
+                Operation::AddTxInput if !utxos.remove(&instruction.inputs[1]) => {
+                    continue;
                 }
+                // AddTxInput instructions have no output variables so we can remove them and
+                // use `variable_count` above without issue
                 _ => {}
             }
 

--- a/fuzzamoto-ir/src/generators/block.rs
+++ b/fuzzamoto-ir/src/generators/block.rs
@@ -23,10 +23,9 @@ fn grafting_header<R: RngCore>(
     // we need to know the current height first.
     let tip_height = if let Some(nth) = nth {
         nth.height
-    } else if let Some(tip_header) = headers.iter().max_by_key(|h| h.height) {
-        u64::from(tip_header.height)
     } else {
-        return None;
+        let tip_header = headers.iter().max_by_key(|h| h.height)?;
+        u64::from(tip_header.height)
     };
 
     if !meta.recent_blocks().is_empty() {

--- a/fuzzamoto-libafl/src/feedbacks/mod.rs
+++ b/fuzzamoto-libafl/src/feedbacks/mod.rs
@@ -49,7 +49,7 @@ impl CaptureTimeoutFeedback {
         } else {
             testcase.input().as_ref().unwrap().generate_name(None)
         };
-        let file_path = self.objective_dir.join(format!("{prefix}-{base}",));
+        let file_path = self.objective_dir.join(format!("{prefix}-{base}"));
         *testcase.file_path_mut() = Some(file_path);
     }
 }
@@ -158,7 +158,7 @@ impl CrashCauseFeedback {
         } else {
             testcase.input().as_ref().unwrap().generate_name(None)
         };
-        let file_path = self.objective_dir.join(format!("{prefix}-{base}",));
+        let file_path = self.objective_dir.join(format!("{prefix}-{base}"));
         *testcase.file_path_mut() = Some(file_path);
     }
 }

--- a/fuzzamoto-libafl/src/stages/mod.rs
+++ b/fuzzamoto-libafl/src/stages/mod.rs
@@ -151,7 +151,7 @@ where
             }
         }
 
-        log::info!("{} done reducing", std::any::type_name::<M>(),);
+        log::info!("{} done reducing", std::any::type_name::<M>());
 
         if success {
             *self.keep_minimizing.borrow_mut() += 1;

--- a/fuzzamoto-nyx-sys/src/nyx-crash-handler.c
+++ b/fuzzamoto-nyx-sys/src/nyx-crash-handler.c
@@ -193,6 +193,7 @@ int sigaction(int signum, const struct sigaction *act,
   case SIGILL:
   case SIGBUS:
   case SIGABRT:
+  case SIGIOT:
   case SIGTRAP:
   case SIGSYS:
   case SIGSEGV:

--- a/fuzzamoto-scenarios/bin/ir.rs
+++ b/fuzzamoto-scenarios/bin/ir.rs
@@ -400,7 +400,7 @@ where
     fn evaluate_oracles(&mut self) -> ScenarioResult {
         let crash_oracle = CrashOracle::<TX>::default();
         if let OracleResult::Fail(e) = crash_oracle.evaluate(&mut self.inner.target) {
-            return ScenarioResult::Fail(format!("CRASH: CRASH; {e}",));
+            return ScenarioResult::Fail(format!("CRASH: CRASH; {e}"));
         }
 
         #[cfg(feature = "oracle_blocktemplate")]


### PR DESCRIPTION
I noticed it was missing from the list of forbidden signals and still used in `initialize_crash_handling`. Also, fix the clippy issues.