### PR TITLE
fuzzamoto-nyx-sys: revert SIGIOT change, add log fix

### DIFF
--- a/fuzzamoto-nyx-sys/src/nyx-crash-handler.c
+++ b/fuzzamoto-nyx-sys/src/nyx-crash-handler.c
@@ -193,7 +193,6 @@ int sigaction(int signum, const struct sigaction *act,
   case SIGILL:
   case SIGBUS:
   case SIGABRT:
-  case SIGIOT:
   case SIGTRAP:
   case SIGSYS:
   case SIGSEGV:

--- a/fuzzamoto-nyx-sys/src/nyx-crash-handler.c
+++ b/fuzzamoto-nyx-sys/src/nyx-crash-handler.c
@@ -241,7 +241,7 @@ void initialize_crash_handling() {
     }
   }
 
-  LOG("[info] All signal handlers installed!\n")
+  LOG("[info] All signal handlers installed!\n");
 }
 #else
 void initialize_crash_handling() {}


### PR DESCRIPTION
The first commit of https://github.com/dergoegge/fuzzamoto/pull/137 doesn't compile with `-D_CATCH_SIGNALS`, yet I missed it because my script will run fuzzamoto no problem (my bad). So revert it.

The second commit adds a semi-colon because it didn't compile in the first place.

Compiler output:
```
./fuzzamoto-nyx-sys/src/nyx-crash-handler.c:196:8: error: duplicate case value '6'
  196 |   case SIGIOT:
      |        ^
/usr/include/x86_64-linux-gnu/bits/signum-arch.h:58:17: note: expanded from macro 'SIGIOT'
   58 | #define SIGIOT          SIGABRT /* IOT instruction, abort() on a PDP-11.  */
      |                         ^
/usr/include/x86_64-linux-gnu/bits/signum-generic.h:50:18: note: expanded from macro 'SIGABRT'
   50 | #define SIGABRT         6       /* Abnormal termination.  */
      |                         ^
./fuzzamoto-nyx-sys/src/nyx-crash-handler.c:195:8: note: previous case defined here
  195 |   case SIGABRT:
      |        ^
/usr/include/x86_64-linux-gnu/bits/signum-generic.h:50:18: note: expanded from macro 'SIGABRT'
   50 | #define SIGABRT         6       /* Abnormal termination.  */
      |                         ^
./fuzzamoto-nyx-sys/src/nyx-crash-handler.c:245:49: error: expected ';' after expression
  245 |   LOG("[info] All signal handlers installed!\n")
      |                                                 ^
      |                                                 ;
2 errors generated.

```