### PR TITLE
add --seedprogram feature

### DIFF
--- a/fuzzamoto-cli/src/commands/init.rs
+++ b/fuzzamoto-cli/src/commands/init.rs
@@ -2,6 +2,13 @@ use crate::error::{CliError, Result};
 use crate::utils::{file_ops, nyx, process};
 use std::path::{Path, PathBuf};
 
+#[derive(Copy, Clone)]
+pub struct InitOptions<'a> {
+    pub secondary_bitcoind: Option<&'a PathBuf>,
+    pub rpc_path: Option<&'a PathBuf>,
+    pub seedprogram: Option<&'a PathBuf>,
+}
+
 pub struct InitCommand;
 
 impl InitCommand {
@@ -9,11 +16,15 @@ impl InitCommand {
         sharedir: &Path,
         crash_handler: &Path,
         bitcoind: &Path,
-        secondary_bitcoind: Option<&PathBuf>,
         scenario: &Path,
         nyx_dir: &Path,
-        rpc_path: Option<&PathBuf>,
+        options: InitOptions<'_>,
     ) -> Result<()> {
+        let InitOptions {
+            secondary_bitcoind,
+            rpc_path,
+            seedprogram,
+        } = options;
         file_ops::ensure_sharedir_not_exists(sharedir)?;
         file_ops::create_dir_all(sharedir)?;
 
@@ -28,6 +39,11 @@ impl InitCommand {
         if let Some(rpc) = rpc_path {
             file_ops::ensure_file_exists(rpc)?;
             file_ops::copy_file_to_dir(rpc, sharedir)?;
+        }
+
+        if let Some(seed) = seedprogram {
+            file_ops::ensure_file_exists(seed)?;
+            file_ops::copy_file_to_dir(seed, sharedir)?;
         }
 
         let mut all_deps = Vec::new();
@@ -117,14 +133,22 @@ impl InitCommand {
             .and_then(|p| p.file_name())
             .and_then(|name| name.to_str());
 
+        let seedprogram_name = seedprogram
+            .as_ref()
+            .and_then(|p| p.file_name())
+            .and_then(|name| name.to_str());
+
         nyx::create_nyx_script(
             sharedir,
             &all_deps,
             &binary_names,
             &crash_handler_name,
             scenario_name,
-            secondary_name,
-            rpc_name,
+            nyx::NyxScriptConfig {
+                secondary_bitcoind: secondary_name,
+                rpc_path: rpc_name,
+                seedprogram: seedprogram_name,
+            },
         )?;
 
         Ok(())

--- a/fuzzamoto-cli/src/main.rs
+++ b/fuzzamoto-cli/src/main.rs
@@ -3,7 +3,7 @@ mod error;
 mod utils;
 
 use clap::{Parser, Subcommand};
-use commands::{CoverageCommand, InitCommand, IrCommand, ir};
+use commands::{CoverageCommand, InitCommand, IrCommand, init::InitOptions, ir};
 use error::Result;
 use std::path::PathBuf;
 
@@ -51,6 +51,12 @@ enum Commands {
             help = "Path to the file with the RPC commands that should be copied into the share directory"
         )]
         rpc_path: Option<PathBuf>,
+
+        #[arg(
+            long,
+            help = "Path to a serialized IR seed program to execute before the Nyx snapshot"
+        )]
+        seedprogram: Option<PathBuf>,
     },
 
     /// Create a html coverage report for a given corpus
@@ -133,14 +139,18 @@ fn main() -> Result<()> {
             scenario,
             nyx_dir,
             rpc_path,
+            seedprogram,
         } => InitCommand::execute(
             sharedir,
             crash_handler,
             bitcoind,
-            secondary_bitcoind.as_ref(),
             scenario,
             nyx_dir,
-            rpc_path.as_ref(),
+            InitOptions {
+                secondary_bitcoind: secondary_bitcoind.as_ref(),
+                rpc_path: rpc_path.as_ref(),
+                seedprogram: seedprogram.as_ref(),
+            },
         ),
         Commands::Coverage {
             output,

--- a/fuzzamoto-cli/src/utils/nyx.rs
+++ b/fuzzamoto-cli/src/utils/nyx.rs
@@ -43,15 +43,26 @@ pub fn generate_nyx_config(nyx_path: &Path, sharedir: &Path) -> Result<()> {
     Ok(())
 }
 
+#[derive(Copy, Clone)]
+pub struct NyxScriptConfig<'a> {
+    pub secondary_bitcoind: Option<&'a str>,
+    pub rpc_path: Option<&'a str>,
+    pub seedprogram: Option<&'a str>,
+}
+
 pub fn create_nyx_script(
     sharedir: &Path,
     all_deps: &[String],
     binary_names: &[String],
     crash_handler_name: &str,
     scenario_name: &str,
-    secondary_bitcoind: Option<&str>,
-    rpc_path: Option<&str>,
+    config: NyxScriptConfig<'_>,
 ) -> Result<()> {
+    let NyxScriptConfig {
+        secondary_bitcoind,
+        rpc_path,
+        seedprogram,
+    } = config;
     let mut script = vec![
         "chmod +x hget".to_string(),
         "cp hget /tmp".to_string(),
@@ -69,6 +80,10 @@ pub fn create_nyx_script(
 
     if let Some(rpc_path) = rpc_path {
         script.push(format!("./hget {rpc_path} {rpc_path}"));
+    }
+
+    if let Some(seed) = seedprogram {
+        script.push(format!("./hget {seed} {seed}"));
     }
 
     // Make executables
@@ -134,11 +149,15 @@ pub fn create_nyx_script(
     };
 
     // Run the scenario
+    let seedprogram_arg = seedprogram
+        .map(|s| format!("--seedprogram /tmp/{s}"))
+        .unwrap_or_default();
     script.push(format!(
-        "RUST_LOG=debug LD_LIBRARY_PATH=/tmp LD_BIND_NOW=1 ./{} ./bitcoind_proxy {} {} > log.txt 2>&1",
+        "RUST_LOG=debug LD_LIBRARY_PATH=/tmp LD_BIND_NOW=1 ./{} ./bitcoind_proxy {} {} {} > log.txt 2>&1",
         scenario_name,
         rpc_path.unwrap_or(""),
         secondary_arg,
+        seedprogram_arg,
     ));
 
     // Debug info

--- a/fuzzamoto-ir/src/compiler.rs
+++ b/fuzzamoto-ir/src/compiler.rs
@@ -25,7 +25,7 @@ use bitcoin::{
     taproot::{LeafVersion, NodeInfo, TapLeafHash, TapNodeHash},
     transaction,
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::{any::Any, convert::TryInto, time::Duration};
 
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
@@ -33,7 +33,16 @@ use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use crate::{
     AddrNetwork, AddrRecord, Instruction, Operation, Program, TaprootKeypair, TaprootLeaf,
     TaprootSpendInfo, bloom::filter_insert, generators::block::Header,
+    generators::txo::Txo as IrTxo,
 };
+
+/// Return type of [`Compiler::into_accumulated_context`]: (txos, headers, timestamp, spent).
+pub type AccumulatedContext = (
+    Vec<IrTxo>,
+    Vec<Header>,
+    Option<u64>,
+    HashSet<([u8; 32], u32)>,
+);
 
 /// `Compiler` is responsible for compiling IR into a sequence of low-level actions to be performed
 /// on a node (i.e. mapping `fuzzamoto_ir::Program` -> `CompiledProgram`).
@@ -43,6 +52,16 @@ pub struct Compiler {
     variables: Vec<Box<dyn Any>>,
     output: CompiledProgram,
     connection_counter: usize,
+
+    accumulate_context: bool,
+    accumulated_txos: Vec<IrTxo>,
+    /// Coinbase outputs paired with the height of the block that created them. Coinbase outputs are
+    /// only spendable after `COINBASE_MATURITY` confirmations, so maturity is resolved against the
+    /// final chain tip in `into_accumulated_context` rather than released eagerly here.
+    accumulated_coinbase_txos: Vec<(u32, IrTxo)>,
+    accumulated_headers: Vec<Header>,
+    accumulated_timestamp: Option<u64>,
+    accumulated_spent: HashSet<([u8; 32], u32)>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
@@ -540,7 +559,61 @@ impl Compiler {
                 metadata: CompiledMetadata::new(),
             },
             connection_counter: 0,
+            accumulate_context: false,
+            accumulated_txos: Vec::new(),
+            accumulated_coinbase_txos: Vec::new(),
+            accumulated_headers: Vec::new(),
+            accumulated_timestamp: None,
+            accumulated_spent: HashSet::new(),
         }
+    }
+
+    /// Create a compiler that simultaneously builds a `FullProgramContext` during compilation.
+    /// After calling `compile`, use `into_accumulated_context` to retrieve the collected data.
+    #[must_use]
+    pub fn new_with_context_accumulation() -> Self {
+        Self {
+            accumulate_context: true,
+            ..Self::new()
+        }
+    }
+
+    /// Consume the compiler and return the TXOs, headers, optional timestamp, and spent outpoints
+    /// accumulated during compilation. Only meaningful when created with
+    /// `new_with_context_accumulation`. The returned TXOs are already filtered to exclude any
+    /// outputs that were spent within the same program.
+    #[must_use]
+    pub fn into_accumulated_context(self) -> AccumulatedContext {
+        // The chain tip after the program ran. A spend referencing an accumulated coinbase output
+        // would be mined no earlier than `tip_height + 1`, so it's only mature when
+        // `(tip_height + 1) - coinbase_height >= COINBASE_MATURITY`.
+        let tip_height = self
+            .accumulated_headers
+            .iter()
+            .map(|header| header.height)
+            .max();
+        let mature_coinbase_txos =
+            self.accumulated_coinbase_txos
+                .into_iter()
+                .filter_map(|(coinbase_height, txo)| {
+                    let spend_height = tip_height? + 1;
+                    (spend_height.saturating_sub(coinbase_height)
+                        >= bitcoin::blockdata::constants::COINBASE_MATURITY)
+                        .then_some(txo)
+                });
+
+        let txos = self
+            .accumulated_txos
+            .into_iter()
+            .chain(mature_coinbase_txos)
+            .filter(|txo| !self.accumulated_spent.contains(&txo.outpoint))
+            .collect();
+        (
+            txos,
+            self.accumulated_headers,
+            self.accumulated_timestamp,
+            self.accumulated_spent,
+        )
     }
 
     fn update_connection_map(
@@ -1761,8 +1834,11 @@ impl Compiler {
                 self.append_variable(*time_var + duration_var.as_secs());
             }
             Operation::SetTime => {
-                let time_var = self.get_input::<u64>(&instruction.inputs, 0)?;
-                self.output.actions.push(CompiledAction::SetTime(*time_var));
+                let time_var = *self.get_input::<u64>(&instruction.inputs, 0)?;
+                self.output.actions.push(CompiledAction::SetTime(time_var));
+                if self.accumulate_context {
+                    self.accumulated_timestamp = Some(time_var);
+                }
             }
             _ => unreachable!("Non-time operation passed to handle_time_operations"),
         }
@@ -2043,6 +2119,35 @@ impl Compiler {
 
         coinbase_tx_var.tx.txos = txos;
         coinbase_tx_var.tx.id = Txid::from_byte_array(coinbase_txid);
+
+        if self.accumulate_context {
+            let new_header = Header {
+                prev: *block.header.prev_blockhash.as_byte_array(),
+                merkle_root: *block.header.merkle_root.as_byte_array(),
+                bits: block.header.bits.to_consensus(),
+                time: block.header.time,
+                height: header_var.height + 1,
+                nonce: block.header.nonce,
+                version: block.header.version.to_consensus(),
+            };
+            let coinbase_height = new_header.height;
+            self.accumulated_headers.push(new_header);
+            // Coinbase outputs aren't spendable until they reach maturity; defer the maturity
+            // decision to `into_accumulated_context`, which knows the final chain tip.
+            for txo in &coinbase_tx_var.tx.txos {
+                self.accumulated_coinbase_txos.push((
+                    coinbase_height,
+                    IrTxo {
+                        outpoint: txo.prev_out,
+                        value: txo.value,
+                        script_pubkey: txo.scripts.script_pubkey.clone(),
+                        spending_script_sig: txo.scripts.script_sig.clone(),
+                        spending_witness: txo.scripts.witness.stack.clone(),
+                    },
+                ));
+            }
+        }
+
         let header_var_index = self.variables.len();
         self.append_variable(Header {
             prev: *block.header.prev_blockhash.as_byte_array(),
@@ -2098,12 +2203,16 @@ impl Compiler {
         let mut tx_var = self.get_input_mut::<Tx>(&instruction.inputs, 0)?.clone();
 
         // Fill in the inputs and outputs
+        let mut newly_spent: Vec<([u8; 32], u32)> = Vec::new();
         tx_var
             .tx
             .input
             .extend(tx_inputs_var.inputs.iter().map(|tx_input| {
                 let txo_var = self.get_variable::<Txo>(tx_input.txo_var).unwrap();
                 let sequence_var = self.get_variable::<u32>(tx_input.sequence_var).unwrap();
+                if self.accumulate_context {
+                    newly_spent.push(txo_var.prev_out);
+                }
                 TxIn {
                     previous_output: OutPoint::new(
                         Txid::from_slice_delegated(&txo_var.prev_out.0).unwrap(),
@@ -2114,6 +2223,7 @@ impl Compiler {
                     sequence: Sequence(*sequence_var),
                 }
             }));
+        self.accumulated_spent.extend(newly_spent);
 
         tx_var.tx.output.extend(
             tx_outputs_var
@@ -2317,6 +2427,19 @@ impl Compiler {
             .collect();
 
         tx_var.id = txid;
+
+        if self.accumulate_context {
+            for txo in &tx_var.txos {
+                self.accumulated_txos.push(IrTxo {
+                    outpoint: txo.prev_out,
+                    value: txo.value,
+                    script_pubkey: txo.scripts.script_pubkey.clone(),
+                    spending_script_sig: txo.scripts.script_sig.clone(),
+                    spending_witness: txo.scripts.witness.stack.clone(),
+                });
+            }
+        }
+
         self.append_variable(tx_var);
 
         Ok(())

--- a/fuzzamoto-scenarios/bin/ir.rs
+++ b/fuzzamoto-scenarios/bin/ir.rs
@@ -530,12 +530,9 @@ where
     fn new(args: &[String]) -> Result<Self, String> {
         let inner: GenericScenario<TX, T> = GenericScenario::new(args)?;
 
-        let context = Self::build_program_context(&inner);
-        log::info!("IR context: {context:?}");
-
-        let txos = Self::build_txos(&inner);
-        let headers = Self::build_headers(&inner);
-        Self::dump_context(context, txos, headers)?;
+        // Collect initial TXOs and headers from the 200-block chain setup.
+        let mut txos = Self::build_txos(&inner);
+        let mut headers = Self::build_headers(&inner);
 
         #[cfg(any(feature = "oracle_netsplit", feature = "oracle_consensus"))]
         let second = Self::create_and_sync_second_target(args, &inner.target)?;
@@ -544,14 +541,61 @@ where
             .header
             .time;
 
-        Ok(Self {
+        let mut scenario = Self {
             inner,
             recording_received_messages: false,
             probe_results: Vec::new(),
             #[cfg(any(feature = "oracle_netsplit", feature = "oracle_consensus"))]
             second,
             futurest: u64::from(genesis_time),
-        })
+        };
+
+        // If a seed program is provided, compile it (simultaneously building context), run it,
+        // and extend the initial TXOs/headers with whatever the seed program produced.
+        let seedprogram_path = args
+            .windows(2)
+            .find(|w| w[0] == "--seedprogram")
+            .map(|w| w[1].clone());
+
+        let mut seed_timestamp: Option<u64> = None;
+
+        if let Some(path) = seedprogram_path {
+            let bytes = std::fs::read(&path).map_err(|e| e.to_string())?;
+            let program: Program = postcard::from_bytes(&bytes).map_err(|e| e.to_string())?;
+
+            let mut compiler = Compiler::new_with_context_accumulation();
+            let compiled = compiler.compile(&program).map_err(|e| e.to_string())?;
+            let (seed_txos, seed_headers, ts, spent) = compiler.into_accumulated_context();
+
+            // Remove any initial (200-block chain) UTXOs that the seed program spent; the compiler
+            // has no knowledge of those, so we filter them here using the returned `spent` set.
+            txos.retain(|txo| !spent.contains(&txo.outpoint));
+            // `seed_txos` are already filtered against `spent` inside `into_accumulated_context`, so
+            // outputs the seed program created and then spent itself are not present here.
+            txos.extend(seed_txos);
+            headers.extend(seed_headers);
+            seed_timestamp = ts;
+
+            log::info!(
+                "Processing seed program with {} actions",
+                compiled.actions.len()
+            );
+            scenario.process_actions(compiled);
+
+            #[cfg(any(feature = "oracle_netsplit", feature = "oracle_consensus"))]
+            Self::sync_nodes(&scenario.inner.target, &mut scenario.second)?;
+        }
+
+        // Build the context after running the seed program so that num_connections
+        // reflects any connections added by the seed program.
+        let mut context = Self::build_program_context(&scenario.inner);
+        if let Some(ts) = seed_timestamp {
+            context.timestamp = ts;
+        }
+        log::info!("IR context: {context:?}");
+        Self::dump_context(context, txos, headers)?;
+
+        Ok(scenario)
     }
 
     fn run(&mut self, testcase: TestCase) -> ScenarioResult {


### PR DESCRIPTION
This PR implements the `--seedprogram` feature which allows an IR program to be executed against the target node before the snapshot is taken, so the fuzzer starts from a richer initial state. I've mostly implemented the idea from https://github.com/dergoegge/fuzzamoto/pull/131#discussion_r2990261211.