### PR TITLE
Revert "ir: skip TakeTxo for OutputType::OpReturn"

### DIFF
--- a/fuzzamoto-ir/src/generators/tx.rs
+++ b/fuzzamoto-ir/src/generators/tx.rs
@@ -174,12 +174,9 @@ fn build_tx<R: RngCore>(
         &Operation::EndBuildTx,
     );
 
-    // Make every output of the transaction spendable except OpReturn
+    // Make every output of the transaction spendable
     let mut outputs = Vec::new();
     for (_, output_type) in output_amounts {
-        if matches!(output_type, OutputType::OpReturn) {
-            continue;
-        }
         let mut txo_var =
             builder.force_append_expect_output(vec![const_tx_var.index], &Operation::TakeTxo);
         if matches!(output_type, OutputType::PayToTaproot) && rng.gen_bool(0.5) {


### PR DESCRIPTION
It doesn't do what I thought because `TakeTxo` increments an index in the compiler. If it's skipped for `OpReturn`, then the next non-`OpReturn` output will just call `TakeTxo` for the `OpReturn` one. It can instead be fixed if `TakeTxo` takes an index argument, but I don't know when I'll have a free minute to do that. So revert for now.