### PR TITLE
Avoid O(prefills × block-txs) work when compiling cmpctblocks

### DIFF
--- a/fuzzamoto-ir/src/compiler.rs
+++ b/fuzzamoto-ir/src/compiler.rs
@@ -1789,12 +1789,16 @@ impl Compiler {
                 });
             }
             Operation::AddPrefillTx => {
-                let block = self
-                    .get_input::<bitcoin::Block>(&instruction.inputs, 1)?
-                    .clone();
-                let tx_to_prefill = self.get_input::<Tx>(&instruction.inputs, 2)?;
-                let tx_to_prefill_id = tx_to_prefill.id;
+                let prefill_len = self
+                    .get_input::<PrefillTransactions>(&instruction.inputs, 0)?
+                    .indices
+                    .len();
+                let block = self.get_input::<bitcoin::Block>(&instruction.inputs, 1)?;
+                if prefill_len >= block.txdata.len().saturating_sub(1) {
+                    return Ok(());
+                }
 
+                let tx_to_prefill_id = self.get_input::<Tx>(&instruction.inputs, 2)?.id;
                 // Find the position of this tx within the block's non-coinbase transactions.
                 // If the tx is not part of this block, skip it silently.
                 let Some(position) = block.txdata[1..]


### PR DESCRIPTION
Noticed this while investigating some timeouts I got even increasing the hang multiple.

`AddPrefillTx` cloned the entire block and rescanned every transaction's txid on each invocation, so a program with many prefill entries did work proportional to prefills x block-txs even though the resulting compact block can hold at most block-txs prefills. Mutated programs could spend seconds in compilation.

Take the block by reference instead of cloning it (the borrow ends before the mutable PrefillTransactions access, so no clone is needed), and skip early once every non-coinbase transaction is already prefilled. This bounds the txid rescans by the block's transaction count rather than the number of prefill instructions.