### PR TITLE
fuzzamoto-nyx-sys: page-align `host_config`

### DIFF
--- a/fuzzamoto-nyx-sys/src/nyx-agent.c
+++ b/fuzzamoto-nyx-sys/src/nyx-agent.c
@@ -15,6 +15,15 @@
 
 #include "nyx.h"
 
+// Due to a bug in QEMU-Nyx's write_virtual_memory(), any guest memory that is
+// written to via that function must either be page-aligned or not cross a page
+// boundary. See https://github.com/nyx-fuzz/QEMU-Nyx/pull/73.
+//
+// Currently the only hypercall we use that is affected by this bug is
+// HYPERCALL_KAFL_GET_HOST_CONFIG, so we page-align the host_config_t used in
+// that hypercall.
+#define NYX_HYPERCALL_ALIGN _Alignas(4096)
+
 // If we're keeping track of coverage for both the target and the scenario
 // processes, then we use a single large map to combine the coverage:
 //
@@ -40,7 +49,7 @@ size_t nyx_init() {
   }
   done = 1;
 
-  host_config_t host_config;
+  NYX_HYPERCALL_ALIGN host_config_t host_config;
   kAFL_hypercall(HYPERCALL_KAFL_GET_HOST_CONFIG, (uintptr_t)&host_config);
 
   if (host_config.host_magic != NYX_HOST_MAGIC) {


### PR DESCRIPTION
If `host_config` is not page aligned and spans a page boundary, QEMU-Nyx has a [bug](https://github.com/nyx-fuzz/QEMU-Nyx/pull/73) that makes it fail to write data to the struct fields located on the second page.  To work around this bug we page-align `host_config`.

This issue was discovered in Smite while trying to fuzz morehouse/smite#114.  The memory layout when fuzzing that PR on my machine just happened to cause `host_config` to span two virtual pages and trigger the bug:

```
[QEMU-NYX] Booting VM to start fuzzing...
[!] libnyx: input buffer is write protected
[hget] 13088 bytes received from hypervisor! (hcat_no_pt)
[hget] 13040 bytes received from hypervisor! (habort_no_pt)
[hget] 143269888 bytes received from hypervisor! (container.tar)
[hcat] 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
[capablities] host_config.bitmap_size: 0xffffd090
[capablities] host_config.ijon_bitmap_size: 0x7fff
[capablities] host_config.payload_buffer_size: 0x0x
[init] using TARGET_MAP_SIZE: 744745
[init] scenario not compiled with afl instrumentation
[QEMU-NYX] Error: Payload buffer at 0xffffffffffffffff is not page-aligned!
[!] libnyx failed to initialize QEMU-Nyx: agent abort() -> 
	Payload buffer at 0xffffffffffffffff is not page-aligned!

[-] PROGRAM ABORT : Something went wrong ...
         Location : afl_fsrv_start(), src/afl-forkserver.c:839
```

Notice the `host_config` values are all garbage.