### PR TITLE
fuzzamoto-nyx-sys: zero-init `host_config`

### DIFF
--- a/fuzzamoto-nyx-sys/src/nyx-agent.c
+++ b/fuzzamoto-nyx-sys/src/nyx-agent.c
@@ -49,7 +49,9 @@ size_t nyx_init() {
   }
   done = 1;
 
-  NYX_HYPERCALL_ALIGN host_config_t host_config;
+  // Zero-initialize host_config to ensure its memory page is faulted in.
+  // Otherwise the hypercall will fail to populate it.
+  NYX_HYPERCALL_ALIGN host_config_t host_config = {0};
   kAFL_hypercall(HYPERCALL_KAFL_GET_HOST_CONFIG, (uintptr_t)&host_config);
 
   if (host_config.host_magic != NYX_HOST_MAGIC) {


### PR DESCRIPTION
If the page where `host_config` resides isn't faulted in, the `HYPERCALL_KAFL_GET_HOST_CONFIG` hypercall fails to write to `host_config`. By zero-initializing `host_config` we ensure its page resides in memory.

Follow-up to #144.  See https://github.com/morehouse/smite/pull/122#issuecomment-4712437435 for more context.