### PR TITLE
Update links to use oss-garage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ of Bitcoin full node implementations.
 *It is not meant to be a replacement for traditional fuzzing of isolated
 components, but rather a complement to it.*
 
-Check out the [book](https://dergoegge.github.io/fuzzamoto/index.html) for more information.
+Check out the [book](https://oss-garage.github.io/fuzzamoto/index.html) for more information.
 
 ## Trophies
 

--- a/doc/src/contributing/ir.md
+++ b/doc/src/contributing/ir.md
@@ -1,7 +1,7 @@
 # Extending Fuzzamoto IR
 
 This guide explains how to add a new IR primitive end to end. Refer to the [IR
-docs](https://dergoegge.github.io/fuzzamoto/design/ir.html) for a high level
+docs](https://oss-garage.github.io/fuzzamoto/design/ir.html) for a high level
 design overview.
 
 ## Model the primitive
@@ -47,10 +47,10 @@ design overview.
 A few PRs that show how IR primitives were added end-to-end:
 
 - [PR #28 - fuzzamoto-ir: Add support for compact block inventory
-  items](https://github.com/dergoegge/fuzzamoto/pull/28)
+  items](https://github.com/oss-garage/fuzzamoto/pull/28)
 - [PR #46 - fuzzamoto-ir/libafl: Expand IR with addr relay (v1&v2)
-  primitives](https://github.com/dergoegge/fuzzamoto/pull/46)
+  primitives](https://github.com/oss-garage/fuzzamoto/pull/46)
 - [PR #45 - Add filterload, filteradd, filterclear handling to
-  fuzzamoto-ir](https://github.com/dergoegge/fuzzamoto/pull/45)
+  fuzzamoto-ir](https://github.com/oss-garage/fuzzamoto/pull/45)
 - [PR #38 - fuzzamoto-ir: add
-  CoinbaseTxGenerator](https://github.com/dergoegge/fuzzamoto/pull/38)
+  CoinbaseTxGenerator](https://github.com/oss-garage/fuzzamoto/pull/38)


### PR DESCRIPTION
I have noticed that the github.io links are broken: https://dergoegge.github.io/fuzzamoto/index.html

This PR fixes that.

It also updates github.com links to point to the new location, even though there is a redirect. 