### PR TITLE
remove references to libevent

### DIFF
--- a/fuzzamoto/src/targets/bitcoin_core.rs
+++ b/fuzzamoto/src/targets/bitcoin_core.rs
@@ -51,11 +51,9 @@ impl BitcoinCoreTarget {
 
         #[cfg(feature = "inherit_stdout")]
         {
-            config.args.extend_from_slice(&[
-                "-debug",
-                "-debugexclude=libevent",
-                "-debugexclude=leveldb",
-            ]);
+            config
+                .args
+                .extend_from_slice(&["-debug", "-debugexclude=leveldb"]);
             config.view_stdout = true;
         }
         config.args.extend_from_slice(&[

--- a/target-patches/bitcoin-core-ir-denylist.txt
+++ b/target-patches/bitcoin-core-ir-denylist.txt
@@ -7,7 +7,6 @@ src:*/qt/*
 src:*/ipc/*
 src:*/wallet/*
 src:*/univalue/*
-src:*libevent/*
 src:*sqlite/*
 
 httpserver.h


### PR DESCRIPTION
`-debugexclude=libevent` will now log a deprecation warning, and be an error in future.